### PR TITLE
Feature/command-subtyping-for-issue-15 コマンドの引数を取る or 取らないを完全に分離するため, クラスを分けて表現

### DIFF
--- a/src/matsu/num/statistics/kdeapp/kde1d/ArgumentRequiringCommand.java
+++ b/src/matsu/num/statistics/kdeapp/kde1d/ArgumentRequiringCommand.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2026 Matsuura Y.
+ * 
+ * This software is released under the MIT License.
+ * http://opensource.org/licenses/mit-license.php
+ */
+
+/*
+ * 2026.2.6
+ */
+package matsu.num.statistics.kdeapp.kde1d;
+
+import static java.util.stream.Collectors.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * 引数をとるコマンドを扱うクラス.
+ * 各インスタンスはシングルトンで表現される.
+ * 
+ * @author Matsuura Y.
+ * @param <T> コマンドの引数の変更先の型, see {@link #convertArg(String)}
+ */
+final class ArgumentRequiringCommand<T> extends ConsoleOptionCommand {
+
+    /**
+     * 入力ファイルの指定を表現するシングルトンインスタンス.
+     */
+    public static final ArgumentRequiringCommand<String> INPUT_FILE_PATH =
+            new ArgumentRequiringCommand<>("INPUT_FILE_PATH", "--input-file", "-f");
+
+    /**
+     * 入力のコメント行の prefix の指定を表現するシングルトンインスタンス.
+     */
+    public static final ArgumentRequiringCommand<String> COMMENT_CHAR =
+            new ArgumentRequiringCommand<>("COMMENT_CHAR", "--comment-char");
+
+    /**
+     * 区切り文字の指定を表現するシングルトンインスタンス.
+     */
+    public static final ArgumentRequiringCommand<Character> SEPARATOR =
+            new ArgumentRequiringCommand<>("SEPARATOR", "--separator", "-sep");
+
+    /**
+     * 出力のラベルに付与する prefix の指定を表現するシングルトンインスタンス.
+     */
+    public static final ArgumentRequiringCommand<String> LABEL_HEADER =
+            new ArgumentRequiringCommand<>("LABEL_HEADER", "--label-header");
+
+    /**
+     * 内部から呼ばれる唯一のコンストラクタ.
+     */
+    private ArgumentRequiringCommand(String enumString, String commandString, String... asString) {
+        super(enumString, commandString, asString);
+    }
+
+    /**
+     * このクラスのシングルトンインスタンスの集合を取得する. <br>
+     * 不変コレクション.
+     * 
+     * @return シングルトンインスタンスの集合
+     */
+    static Collection<ArgumentRequiringCommand<?>> values() {
+        // ここはリフレクションで処理したい
+        return SingletonHolder.values;
+    }
+
+    /**
+     * テスト用. <br>
+     * シングルトンインスタンスの全コマンド文字列表現のリストを得る.
+     * 
+     * @return 文字列表現リスト
+     */
+    static List<String> allExpressions() {
+
+        return values().stream()
+                .flatMap(command -> command.expressions().stream())
+                .toList();
+    }
+
+    private static final class SingletonHolder {
+
+        /**
+         * オプションコマンドの集合. <br>
+         * 不変になるようにすること.
+         */
+        static final Collection<ArgumentRequiringCommand<?>> values;
+
+        static {
+            List<ArgumentRequiringCommand<?>> constantFieldList = new ArrayList<>();
+
+            @SuppressWarnings("rawtypes")
+            Class<ArgumentRequiringCommand> clazz = ArgumentRequiringCommand.class;
+
+            // staticかつ互換性のあるフィールドのみが対象
+            for (Field f : ArgumentRequiringCommand.class.getFields()) {
+                if ((f.getModifiers() & Modifier.STATIC) == 0) {
+                    continue;
+                }
+                try {
+                    constantFieldList.add(clazz.cast(f.get(null)));
+                } catch (IllegalAccessException | ClassCastException ignore) {
+                    //無関係なフィールドなら無視する
+                }
+            }
+
+            values = List.copyOf(constantFieldList);
+        }
+    }
+
+    /**
+     * 与えられた文字列からオプションコマンドを解釈して返す.
+     * 
+     * @param commandAsString 文字列表現
+     * @return 該当するオプションコマンド, 該当なしなら空
+     * @throws NullPointerException 引数がnull
+     */
+    static Optional<ArgumentRequiringCommand<?>> interpret(String commandAsString) {
+        return OptionCommandStringInterpreter.interpret(commandAsString);
+    }
+
+    private static final class OptionCommandStringInterpreter {
+
+        private static final Map<String, ArgumentRequiringCommand<?>> toOptionMapper;
+
+        static {
+
+            // フラット化
+            List<Pair> pairs = ArgumentRequiringCommand.values().stream()
+                    .flatMap(
+                            o -> o.expressions().stream()
+                                    .map(str -> new Pair(o, str)))
+                    .toList();
+
+            // オプションの文字列表現定義に重複がないことを確認する.
+            Map<String, Long> map = pairs.stream()
+                    .map(p -> p.asString)
+                    .collect(groupingBy(s -> s, counting()));
+            for (Map.Entry<String, Long> e : map.entrySet()) {
+                if (e.getValue().longValue() >= 2) {
+                    throw new AssertionError("duplicate: " + e.getKey());
+                }
+            }
+
+            toOptionMapper = pairs.stream()
+                    .collect(toMap(p -> p.asString, p -> p.command));
+        }
+
+        /**
+         * 与えられた文字列からオプションコマンドを解釈して返す.
+         * 
+         * @throws NullPointerException 引数がnull
+         */
+        static Optional<ArgumentRequiringCommand<?>> interpret(String commandAsString) {
+            return Optional.ofNullable(
+                    toOptionMapper.get(Objects.requireNonNull(commandAsString)));
+        }
+
+        // option と String のペアを表現するクラス
+        private static final class Pair {
+            final ArgumentRequiringCommand<?> command;
+            final String asString;
+
+            Pair(ArgumentRequiringCommand<?> command, String asString) {
+                super();
+                this.command = command;
+                this.asString = asString;
+            }
+        }
+    }
+}

--- a/src/matsu/num/statistics/kdeapp/kde1d/ConsoleOptionCommand.java
+++ b/src/matsu/num/statistics/kdeapp/kde1d/ConsoleOptionCommand.java
@@ -6,105 +6,37 @@
  */
 
 /*
- * 2026.2.5
+ * 2026.2.6
  */
 package matsu.num.statistics.kdeapp.kde1d;
 
-import static java.util.stream.Collectors.*;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 /**
  * コンソールオプションコマンドの列挙を表現するクラス.
  * 
  * @author Matsuura Y.
- * @param <T> コマンドの引数の変更先の型, see {@link #convertArg(String)}
  */
-final class ConsoleOptionCommand<T> {
-
-    /**
-     * 入力ファイルの指定を表現するシングルトンインスタンス.
-     * 
-     * <p>
-     * 要arg.
-     * </p>
-     */
-    public static final ConsoleOptionCommand<String> INPUT_FILE_PATH =
-            new ConsoleOptionCommand<>("INPUT_FILE_PATH", true, "--input-file", "-f");
-
-    /**
-     * 入力のコメント行の prefix の指定を表現するシングルトンインスタンス.
-     * 
-     * <p>
-     * 要arg.
-     * </p>
-     */
-    public static final ConsoleOptionCommand<String> COMMENT_CHAR =
-            new ConsoleOptionCommand<>("COMMENT_CHAR", true, "--comment-char");
-
-    /**
-     * 区切り文字の指定を表現するシングルトンインスタンス.
-     * 
-     * <p>
-     * 要arg.
-     * </p>
-     */
-    public static final ConsoleOptionCommand<Character> SEPARATOR =
-            new ConsoleOptionCommand<>("SEPARATOR", true, "--separator", "-sep");
-
-    /**
-     * 出力のラベルに付与する prefix の指定を表現するシングルトンインスタンス.
-     * 
-     * <p>
-     * 要arg.
-     * </p>
-     */
-    public static final ConsoleOptionCommand<String> LABEL_HEADER =
-            new ConsoleOptionCommand<>("LABEL_HEADER", true, "--label-header");
-
-    /**
-     * 引数をとらないダミーオプション, シングルトンインスタンス.
-     * 
-     * <p>
-     * 引数をとらないオプションが導入されたら, このオプションは削除する.
-     * </p>
-     * 
-     * @deprecated ダミーオプション, プロダクトコードから参照してはいけない.
-     */
-    @Deprecated
-    public static final ConsoleOptionCommand<?> DUMMY_NO_ARG =
-            new ConsoleOptionCommand<>("DUMMY_NO_ARG", false, "--dummy-no-arg");
+abstract sealed class ConsoleOptionCommand
+        permits ArgumentRequiringCommand, NoArgumentCommand {
 
     private final String enumString;
 
-    /**
-     * オプションに続くパラメータを持つかどうか.
-     */
-    private final boolean hasArg;
-
     private final String commandString;
-    private final List<String> listOfAsString;
+    private final List<String> expressions;
 
-    private ConsoleOptionCommand(String enumString,
-            boolean hasArg, String commandString, String... asString) {
+    ConsoleOptionCommand(String enumString, String commandString, String... asString) {
 
         this.enumString = enumString;
 
-        this.hasArg = hasArg;
         this.commandString = commandString;
 
-        this.listOfAsString = new ArrayList<>();
-        this.listOfAsString.add(commandString);
-        this.listOfAsString.addAll(List.of(asString));
+        this.expressions = new ArrayList<>();
+        this.expressions.add(commandString);
+        this.expressions.addAll(List.of(asString));
 
-        if (this.listOfAsString.stream().anyMatch(String::isBlank)) {
+        if (this.expressions.stream().anyMatch(String::isBlank)) {
             throw new AssertionError(this.toString() + ": blank string expression");
         }
     }
@@ -114,17 +46,18 @@ final class ConsoleOptionCommand<T> {
      * 
      * @return 正式な文字列表現
      */
-    String commandString() {
+    final String commandString() {
         return commandString;
     }
 
     /**
-     * コマンドに続くべきパラメータの個数を返す.
+     * コマンド文字列表現のリストを得る. <br>
+     * おそらくイミュータブルである.
      * 
-     * @return パラメータの個数
+     * @return 文字列表現リスト
      */
-    boolean hasArg() {
-        return hasArg;
+    final List<String> expressions() {
+        return List.copyOf(expressions);
     }
 
     /**
@@ -133,110 +66,5 @@ final class ConsoleOptionCommand<T> {
     @Override
     public String toString() {
         return this.enumString;
-    }
-
-    /**
-     * 与えられた文字列からオプションコマンドを解釈して返す.
-     * 
-     * @param commandAsString 文字列表現
-     * @return 該当するオプションコマンド, 該当なしなら空
-     * @throws NullPointerException 引数がnull
-     */
-    static Optional<ConsoleOptionCommand<?>> interpret(String commandAsString) {
-        return OptionCommandStringInterpreter.interpret(commandAsString);
-    }
-
-    /**
-     * このクラスのシングルトンインスタンスの集合を取得する. <br>
-     * 不変コレクション.
-     * 
-     * @return シングルトンインスタンスの集合
-     */
-    static Collection<ConsoleOptionCommand<?>> values() {
-        // ここはリフレクションで処理したい
-        return SingletonHolder.values;
-    }
-
-    private static final class OptionCommandStringInterpreter {
-
-        private static final Map<String, ConsoleOptionCommand<?>> toOptionMapper;
-
-        static {
-
-            // フラット化
-            List<Pair> pairs = ConsoleOptionCommand.values().stream()
-                    .flatMap(
-                            o -> o.listOfAsString.stream()
-                                    .map(str -> new Pair(o, str)))
-                    .toList();
-
-            // オプションの文字列表現定義に重複がないことを確認する.
-            Map<String, Long> map = pairs.stream()
-                    .map(p -> p.asString)
-                    .collect(groupingBy(s -> s, counting()));
-            for (Map.Entry<String, Long> e : map.entrySet()) {
-                if (e.getValue().longValue() >= 2) {
-                    throw new AssertionError("duplicate: " + e.getKey());
-                }
-            }
-
-            toOptionMapper = pairs.stream()
-                    .collect(toMap(p -> p.asString, p -> p.command));
-        }
-
-        /**
-         * 与えられた文字列からオプションコマンドを解釈して返す.
-         * 
-         * @throws NullPointerException 引数がnull
-         */
-        static Optional<ConsoleOptionCommand<?>> interpret(String commandAsString) {
-            return Optional.ofNullable(
-                    toOptionMapper.get(Objects.requireNonNull(commandAsString)));
-        }
-
-        // option と String のペアを表現するクラス
-        private static final class Pair {
-            final ConsoleOptionCommand<?> command;
-            final String asString;
-
-            Pair(ConsoleOptionCommand<?> command, String asString) {
-                super();
-                this.command = command;
-                this.asString = asString;
-            }
-        }
-    }
-
-    private static final class SingletonHolder {
-
-        /**
-         * オプションコマンドの集合. <br>
-         * 不変になるようにすること.
-         */
-        static final Collection<ConsoleOptionCommand<?>> values;
-
-        static {
-            // ここはリフレクションで処理したい
-            //            values = List.of(INPUT_FILE_PATH, COMMENT_CHAR, SEPARATOR, LABEL_HEADER, DUMMY_NO_ARG);
-
-            List<ConsoleOptionCommand<?>> constantFieldList = new ArrayList<>();
-
-            @SuppressWarnings("rawtypes")
-            Class<ConsoleOptionCommand> clazz = ConsoleOptionCommand.class;
-
-            // staticかつ互換性のあるフィールドのみが対象
-            for (Field f : ConsoleOptionCommand.class.getFields()) {
-                if ((f.getModifiers() & Modifier.STATIC) == 0) {
-                    continue;
-                }
-                try {
-                    constantFieldList.add(clazz.cast(f.get(null)));
-                } catch (IllegalAccessException | ClassCastException ignore) {
-                    //無関係なフィールドなら無視する
-                }
-            }
-
-            values = List.copyOf(constantFieldList);
-        }
     }
 }

--- a/src/matsu/num/statistics/kdeapp/kde1d/Kde1dSourceLoaderConstructor.java
+++ b/src/matsu/num/statistics/kdeapp/kde1d/Kde1dSourceLoaderConstructor.java
@@ -10,7 +10,7 @@
  */
 package matsu.num.statistics.kdeapp.kde1d;
 
-import static matsu.num.statistics.kdeapp.kde1d.ConsoleOptionCommand.*;
+import static matsu.num.statistics.kdeapp.kde1d.ArgumentRequiringCommand.*;
 
 /**
  * {@link Kde1dSourceLoader} の構築器.

--- a/src/matsu/num/statistics/kdeapp/kde1d/NoArgumentCommand.java
+++ b/src/matsu/num/statistics/kdeapp/kde1d/NoArgumentCommand.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2026 Matsuura Y.
+ * 
+ * This software is released under the MIT License.
+ * http://opensource.org/licenses/mit-license.php
+ */
+
+/*
+ * 2026.2.6
+ */
+package matsu.num.statistics.kdeapp.kde1d;
+
+import static java.util.stream.Collectors.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * 引数をとらないコマンドを扱うクラス.
+ * 各インスタンスはシングルトンで表現される.
+ * 
+ * @author Matsuura Y.
+ */
+final class NoArgumentCommand extends ConsoleOptionCommand {
+
+    /**
+     * 引数をとらないダミーオプション, シングルトンインスタンス. <br>
+     * 引数をとらないオプションが導入されたら, このオプションは削除する.
+     * 
+     * @deprecated ダミーオプション, プロダクトコードから参照してはいけない.
+     */
+    @Deprecated
+    public static final NoArgumentCommand DUMMY_NO_ARG =
+            new NoArgumentCommand("DUMMY_NO_ARG", "--dummy-no-arg");
+
+    /**
+     * 内部から呼ばれる唯一のコンストラクタ.
+     */
+    private NoArgumentCommand(String enumString, String commandString, String... asString) {
+        super(enumString, commandString, asString);
+    }
+
+    /**
+     * このクラスのシングルトンインスタンスの集合を取得する. <br>
+     * 不変コレクション.
+     * 
+     * @return シングルトンインスタンスの集合
+     */
+    static Collection<NoArgumentCommand> values() {
+        // ここはリフレクションで処理したい
+        return SingletonHolder.values;
+    }
+
+    /**
+     * テスト用. <br>
+     * シングルトンインスタンスの全コマンド文字列表現のリストを得る.
+     * 
+     * @return 文字列表現リスト
+     */
+    static List<String> allExpressions() {
+
+        return values().stream()
+                .flatMap(command -> command.expressions().stream())
+                .toList();
+    }
+
+    private static final class SingletonHolder {
+
+        /**
+         * オプションコマンドの集合. <br>
+         * 不変になるようにすること.
+         */
+        static final Collection<NoArgumentCommand> values;
+
+        static {
+            List<NoArgumentCommand> constantFieldList = new ArrayList<>();
+
+            Class<NoArgumentCommand> clazz = NoArgumentCommand.class;
+
+            // staticかつ互換性のあるフィールドのみが対象
+            for (Field f : NoArgumentCommand.class.getFields()) {
+                if ((f.getModifiers() & Modifier.STATIC) == 0) {
+                    continue;
+                }
+                try {
+                    constantFieldList.add(clazz.cast(f.get(null)));
+                } catch (IllegalAccessException | ClassCastException ignore) {
+                    //無関係なフィールドなら無視する
+                }
+            }
+
+            values = List.copyOf(constantFieldList);
+        }
+    }
+
+    /**
+     * 与えられた文字列からオプションコマンドを解釈して返す.
+     * 
+     * @param commandAsString 文字列表現
+     * @return 該当するオプションコマンド, 該当なしなら空
+     * @throws NullPointerException 引数がnull
+     */
+    static Optional<NoArgumentCommand> interpret(String commandAsString) {
+        return OptionCommandStringInterpreter.interpret(commandAsString);
+    }
+
+    private static final class OptionCommandStringInterpreter {
+
+        private static final Map<String, NoArgumentCommand> toOptionMapper;
+
+        static {
+
+            // フラット化
+            List<Pair> pairs = NoArgumentCommand.values().stream()
+                    .flatMap(
+                            o -> o.expressions().stream()
+                                    .map(str -> new Pair(o, str)))
+                    .toList();
+
+            // オプションの文字列表現定義に重複がないことを確認する.
+            Map<String, Long> map = pairs.stream()
+                    .map(p -> p.asString)
+                    .collect(groupingBy(s -> s, counting()));
+            for (Map.Entry<String, Long> e : map.entrySet()) {
+                if (e.getValue().longValue() >= 2) {
+                    throw new AssertionError("duplicate: " + e.getKey());
+                }
+            }
+
+            toOptionMapper = pairs.stream()
+                    .collect(toMap(p -> p.asString, p -> p.command));
+        }
+
+        /**
+         * 与えられた文字列からオプションコマンドを解釈して返す.
+         * 
+         * @throws NullPointerException 引数がnull
+         */
+        static Optional<NoArgumentCommand> interpret(String commandAsString) {
+            return Optional.ofNullable(
+                    toOptionMapper.get(Objects.requireNonNull(commandAsString)));
+        }
+
+        // option と String のペアを表現するクラス
+        private static final class Pair {
+            final NoArgumentCommand command;
+            final String asString;
+
+            Pair(NoArgumentCommand command, String asString) {
+                super();
+                this.command = command;
+                this.asString = asString;
+            }
+        }
+    }
+
+}

--- a/src/matsu/num/statistics/kdeapp/kde1d/WritingFormatterConstructor.java
+++ b/src/matsu/num/statistics/kdeapp/kde1d/WritingFormatterConstructor.java
@@ -10,7 +10,7 @@
  */
 package matsu.num.statistics.kdeapp.kde1d;
 
-import static matsu.num.statistics.kdeapp.kde1d.ConsoleOptionCommand.*;
+import static matsu.num.statistics.kdeapp.kde1d.ArgumentRequiringCommand.*;
 
 /**
  * {@link WritingFormatter} の構築器.

--- a/test/matsu/num/statistics/kdeapp/kde1d/ArgumentRequiringCommandTest.java
+++ b/test/matsu/num/statistics/kdeapp/kde1d/ArgumentRequiringCommandTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2026 Matsuura Y.
+ * 
+ * This software is released under the MIT License.
+ * http://opensource.org/licenses/mit-license.php
+ */
+
+package matsu.num.statistics.kdeapp.kde1d;
+
+import static matsu.num.statistics.kdeapp.kde1d.ArgumentRequiringCommand.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+/**
+ * {@link ArgumentRequiringCommand} のテスト.
+ */
+@RunWith(Enclosed.class)
+final class ArgumentRequiringCommandTest {
+    
+    public static class オプションコマンドの集合生成に関するテスト {
+
+        @Test
+        public void test_INPUT_FILE_PATHを含むことを確かめる() {
+            assertThat(values(), containsInRelativeOrder(INPUT_FILE_PATH));
+        }
+    }
+
+    public static class オプションコマンドの文字列解釈のテスト {
+
+        @Test(expected = NullPointerException.class)
+        public void test_nullは不可() {
+            interpret(null);
+        }
+
+        @Test
+        public void test_セパレータコマンド() {
+            assertThat(
+                    interpret("--separator").get(),
+                    is(SEPARATOR));
+            assertThat(
+                    interpret("-sep").get(),
+                    is(SEPARATOR));
+        }
+
+        @Test
+        public void test_未定義の場合() {
+            assertThat(
+                    interpret("--unknown"),
+                    is(Optional.empty()));
+        }
+    }
+}

--- a/test/matsu/num/statistics/kdeapp/kde1d/ConsoleOptionCommandTest.java
+++ b/test/matsu/num/statistics/kdeapp/kde1d/ConsoleOptionCommandTest.java
@@ -7,12 +7,12 @@
 
 package matsu.num.statistics.kdeapp.kde1d;
 
-import static matsu.num.statistics.kdeapp.kde1d.ConsoleOptionCommand.*;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
 
-import java.util.Optional;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -24,36 +24,20 @@ import org.junit.runner.RunWith;
 @RunWith(Enclosed.class)
 final class ConsoleOptionCommandTest {
 
-    public static class オプションコマンドの集合生成に関するテスト {
+    public static class サブクラスの重複の検証 {
 
         @Test
-        public void test_INPUT_FILE_PATHを含むことを確かめる() {
-            assertThat(values(), containsInRelativeOrder(INPUT_FILE_PATH));
-        }
-    }
+        public void test_サブクラスのコマンド文字列表現が重複しないことを確認() {
+            List<String> argCommandExpressions = ArgumentRequiringCommand.allExpressions();
+            List<String> noArgCommandExpressions = NoArgumentCommand.allExpressions();
 
-    public static class オプションコマンドの文字列解釈のテスト {
+            Set<String> merged = new HashSet<>(argCommandExpressions);
+            merged.addAll(noArgCommandExpressions);
 
-        @Test(expected = NullPointerException.class)
-        public void test_nullは不可() {
-            interpret(null);
-        }
+            int overlapCount = argCommandExpressions.size() +
+                    noArgCommandExpressions.size() - merged.size();
 
-        @Test
-        public void test_セパレータコマンド() {
-            assertThat(
-                    interpret("--separator").get(),
-                    is(ConsoleOptionCommand.SEPARATOR));
-            assertThat(
-                    interpret("-sep").get(),
-                    is(ConsoleOptionCommand.SEPARATOR));
-        }
-
-        @Test
-        public void test_未定義の場合() {
-            assertThat(
-                    interpret("--unknown"),
-                    is(Optional.empty()));
+            assertThat("Subclass-command overlapped count", overlapCount, is(0));
         }
     }
 }

--- a/test/matsu/num/statistics/kdeapp/kde1d/ConsoleParameterInterpreterTest.java
+++ b/test/matsu/num/statistics/kdeapp/kde1d/ConsoleParameterInterpreterTest.java
@@ -7,7 +7,8 @@
 
 package matsu.num.statistics.kdeapp.kde1d;
 
-import static matsu.num.statistics.kdeapp.kde1d.ConsoleOptionCommand.*;
+import static matsu.num.statistics.kdeapp.kde1d.ArgumentRequiringCommand.*;
+import static matsu.num.statistics.kdeapp.kde1d.NoArgumentCommand.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -86,7 +87,7 @@ final class ConsoleParameterInterpreterTest {
         @SuppressWarnings("deprecation")
         @Test
         public void test_dummyNoArgは設定済み() {
-            assertThat(interpretation.valueOf(DUMMY_NO_ARG), not(Optional.empty()));
+            assertThat(interpretation.contains(DUMMY_NO_ARG), is(true));
         }
     }
 }

--- a/test/matsu/num/statistics/kdeapp/kde1d/NoArgumentCommandTest.java
+++ b/test/matsu/num/statistics/kdeapp/kde1d/NoArgumentCommandTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2026 Matsuura Y.
+ * 
+ * This software is released under the MIT License.
+ * http://opensource.org/licenses/mit-license.php
+ */
+
+package matsu.num.statistics.kdeapp.kde1d;
+
+import static matsu.num.statistics.kdeapp.kde1d.NoArgumentCommand.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+/**
+ * {@link NoArgumentCommand} のテスト.
+ */
+@RunWith(Enclosed.class)
+final class NoArgumentCommandTest {
+
+    public static class オプションコマンドの集合生成に関するテスト {
+
+        @SuppressWarnings("deprecation")
+        @Test
+        public void test_DUMMY_NO_ARGを含むことを確かめる() {
+            assertThat(values(), containsInRelativeOrder(DUMMY_NO_ARG));
+        }
+    }
+
+    public static class オプションコマンドの文字列解釈のテスト {
+
+        @Test(expected = NullPointerException.class)
+        public void test_nullは不可() {
+            interpret(null);
+        }
+
+        @SuppressWarnings("deprecation")
+        @Test
+        public void test_ダミーコマンド() {
+            assertThat(
+                    interpret("--dummy-no-arg").get(),
+                    is(DUMMY_NO_ARG));
+        }
+
+        @Test
+        public void test_未定義の場合() {
+            assertThat(
+                    interpret("--unknown"),
+                    is(Optional.empty()));
+        }
+    }
+}


### PR DESCRIPTION
for issue #15 
コマンドの引数を取る or 取らないを完全に分離するため, クラスを分けて表現