### PR TITLE
chore: kde1d-config.properties, kde2d-config.properties をリソースとして管理する

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -7,4 +7,4 @@ dist.label=matsu.num.Statistics.KdeApp
 # other resources
 other.resources=README.md,LICENSE.txt,history.txt
 # other resources flatten
-other.resources.flatten=script/*
+other.resources.flatten=script/*,resources/*

--- a/kde1d-config.properties
+++ b/kde1d-config.properties
@@ -1,1 +1,0 @@
-output.separator=\t

--- a/kde2d-config.properties
+++ b/kde2d-config.properties
@@ -1,2 +1,0 @@
-input.separator=\t
-output.separator=\t

--- a/resources/kde1d-config.properties
+++ b/resources/kde1d-config.properties
@@ -1,0 +1,5 @@
+echo=on
+input.commentprefix=#
+
+output.separator=\t
+output.label=disabled

--- a/resources/kde2d-config.properties
+++ b/resources/kde2d-config.properties
@@ -1,0 +1,7 @@
+echo=on
+input.commentprefix=#
+input.separator=\t
+
+output.formattertype=xyz
+output.separator=\t
+output.label=disabled


### PR DESCRIPTION
for issue #109
kde1d-config.properties, kde2d-config.properties をリソースとして管理する